### PR TITLE
Expand project lists with classic game references

### DIFF
--- a/Proyectos/Games/README.md
+++ b/Proyectos/Games/README.md
@@ -8,60 +8,90 @@ Colección de ejemplos de juegos creados con Unity. Para facilitar la navegació
 | [<img src="https://opengraph.githubassets.com/1/leotgo/BrightSouls" alt="Bright Souls" width="300"/>](https://github.com/leotgo/BrightSouls) | [<img src="https://opengraph.githubassets.com/1/Symon799/AoT_FanGame" alt="Attack on Titan" width="300"/>](https://github.com/Symon799/AoT_FanGame) | [<img src="https://opengraph.githubassets.com/1/OpenMafia/MafiaUnity" alt="Mafia Unity" width="300"/>](https://github.com/OpenMafia/MafiaUnity) |
 | --- | --- | --- |
 | [Bright Souls](https://github.com/leotgo/BrightSouls) | [Attack on Titan Fan Game](https://github.com/Symon799/AoT_FanGame) | [Mafia Unity](https://github.com/OpenMafia/MafiaUnity) |
+| [<img src="https://opengraph.githubassets.com/1/Kefrost/Devil-May-Cry-Lock-On-System" alt="DMC Lock-On" width="300"/>](https://github.com/Kefrost/Devil-May-Cry-Lock-On-System) | [<img src="https://opengraph.githubassets.com/1/Cegamer/God-Of-War-en-Unity" alt="God of War Unity" width="300"/>](https://github.com/Cegamer/God-Of-War-en-Unity) | [<img src="https://opengraph.githubassets.com/1/andrefcasimiro/metal_gear_solid_unity" alt="Metal Gear Solid Unity" width="300"/>](https://github.com/andrefcasimiro/metal_gear_solid_unity) |
+| --- | --- | --- |
+| [DMC Lock-On System](https://github.com/Kefrost/Devil-May-Cry-Lock-On-System) | [God of War Unity](https://github.com/Cegamer/God-Of-War-en-Unity) | [Metal Gear Solid Unity](https://github.com/andrefcasimiro/metal_gear_solid_unity) |
 
 ## Aventura
 
 | [<img src="https://opengraph.githubassets.com/1/Adamaximum/TheStanleyParableClone" alt="The Stanley Parable Clone" width="300"/>](https://github.com/Adamaximum/TheStanleyParableClone) | [<img src="https://opengraph.githubassets.com/1/Trigary/BotMender" alt="BotMender" width="300"/>](https://github.com/Trigary/BotMender) | [<img src="https://opengraph.githubassets.com/1/OpenHogwarts/hogwarts" alt="Hogwarts" width="300"/>](https://github.com/OpenHogwarts/hogwarts) |
 | --- | --- | --- |
 | [The Stanley Parable Clone](https://github.com/Adamaximum/TheStanleyParableClone) | [BotMender](https://github.com/Trigary/BotMender) | [Hogwarts](https://github.com/OpenHogwarts/hogwarts) |
+| [<img src="https://opengraph.githubassets.com/1/Ellard24/Unity2D-Zelda" alt="Unity2D Zelda" width="300"/>](https://github.com/Ellard24/Unity2D-Zelda) | [<img src="https://opengraph.githubassets.com/1/dv-dev-6000/Return-to-Monkey-Island-Unity" alt="Return to Monkey Island" width="300"/>](https://github.com/dv-dev-6000/Return-to-Monkey-Island-Unity) | [<img src="https://opengraph.githubassets.com/1/Joe-V2/MonkeyIslandGame" alt="Monkey Island Game" width="300"/>](https://github.com/Joe-V2/MonkeyIslandGame) |
+| --- | --- | --- |
+| [Unity2D Zelda](https://github.com/Ellard24/Unity2D-Zelda) | [Return to Monkey Island](https://github.com/dv-dev-6000/Return-to-Monkey-Island-Unity) | [Monkey Island Game](https://github.com/Joe-V2/MonkeyIslandGame) |
 
 ## Rol (RPG)
 
 | [<img src="https://opengraph.githubassets.com/1/Denzic/UnityRPG" alt="Unity RPG" width="300"/>](https://github.com/Denzic/UnityRPG) | [<img src="https://opengraph.githubassets.com/1/zombietfk/AnotherUnityThing" alt="Another Unity Thing" width="300"/>](https://github.com/zombietfk/AnotherUnityThing) | [<img src="https://opengraph.githubassets.com/1/blkFinch/JRPG" alt="JRPG" width="300"/>](https://github.com/blkFinch/JRPG) |
 | --- | --- | --- |
 | [Unity RPG](https://github.com/Denzic/UnityRPG) | [Another Unity Thing](https://github.com/zombietfk/AnotherUnityThing) | [JRPG](https://github.com/blkFinch/JRPG) |
+| [<img src="https://opengraph.githubassets.com/1/mofr/Diablerie" alt="Diablerie" width="300"/>](https://github.com/mofr/Diablerie) | [<img src="https://opengraph.githubassets.com/1/PokemonUnity/PokemonUnity" alt="Pokemon Unity" width="300"/>](https://github.com/PokemonUnity/PokemonUnity) | [<img src="https://opengraph.githubassets.com/1/MaKiPL/openviii-unity" alt="OpenVIII" width="300"/>](https://github.com/MaKiPL/openviii-unity) |
+| --- | --- | --- |
+| [Diablerie](https://github.com/mofr/Diablerie) | [Pokemon Unity](https://github.com/PokemonUnity/PokemonUnity) | [OpenVIII](https://github.com/MaKiPL/openviii-unity) |
 
 ## Estrategia
 
 | [<img src="https://opengraph.githubassets.com/1/Senexis/ArenaDefense" alt="Arena Defense" width="300"/>](https://github.com/Senexis/ArenaDefense) | [<img src="https://opengraph.githubassets.com/1/fededevi/Hyperion" alt="Hyperion" width="300"/>](https://github.com/fededevi/Hyperion) | [<img src="https://opengraph.githubassets.com/1/urius/unity-rts-game-prototype" alt="Unity RTS Game" width="300"/>](https://github.com/urius/unity-rts-game-prototype) |
 | --- | --- | --- |
 | [Arena Defense](https://github.com/Senexis/ArenaDefense) | [Hyperion](https://github.com/fededevi/Hyperion) | [Unity RTS Game Prototype](https://github.com/urius/unity-rts-game-prototype) |
+| [<img src="https://opengraph.githubassets.com/1/dolan-and-chris/Project-Musketeer" alt="Project Musketeer" width="300"/>](https://github.com/dolan-and-chris/Project-Musketeer) | [<img src="https://opengraph.githubassets.com/1/coconauts/startcraft-unity3d" alt="Startcraft Unity" width="300"/>](https://github.com/coconauts/startcraft-unity3d) | [<img src="https://opengraph.githubassets.com/1/Doidel/UnityCiv" alt="Unity Civ" width="300"/>](https://github.com/Doidel/UnityCiv) |
+| --- | --- | --- |
+| [Project Musketeer](https://github.com/dolan-and-chris/Project-Musketeer) | [Startcraft Unity](https://github.com/coconauts/startcraft-unity3d) | [Unity Civ](https://github.com/Doidel/UnityCiv) |
 
 ## Simulación
 
 | [<img src="https://opengraph.githubassets.com/1/pepeizq/City-Builder" alt="City Builder" width="300"/>](https://github.com/pepeizq/City-Builder) | [<img src="https://opengraph.githubassets.com/1/LazyDuchess/SimUnity2" alt="SimUnity 2" width="300"/>](https://github.com/LazyDuchess/SimUnity2) | [<img src="https://opengraph.githubassets.com/1/geronimo-lisboa/unity-simcity" alt="Unity SimCity" width="300"/>](https://github.com/geronimo-lisboa/unity-simcity) |
 | --- | --- | --- |
 | [City Builder](https://github.com/pepeizq/City-Builder) | [SimUnity 2](https://github.com/LazyDuchess/SimUnity2) | [Unity SimCity](https://github.com/geronimo-lisboa/unity-simcity) |
+| [<img src="https://opengraph.githubassets.com/1/leoCamilo/FakeSimCity" alt="Fake SimCity" width="300"/>](https://github.com/leoCamilo/FakeSimCity) | [<img src="https://opengraph.githubassets.com/1/bsimser/Micropolis" alt="Micropolis" width="300"/>](https://github.com/bsimser/Micropolis) | [<img src="https://opengraph.githubassets.com/1/LazyDuchess/OpenTS2" alt="OpenTS2" width="300"/>](https://github.com/LazyDuchess/OpenTS2) |
+| --- | --- | --- |
+| [Fake SimCity](https://github.com/leoCamilo/FakeSimCity) | [Micropolis](https://github.com/bsimser/Micropolis) | [OpenTS2](https://github.com/LazyDuchess/OpenTS2) |
 
 ## Deportes
 
 | [<img src="https://opengraph.githubassets.com/1/Jonek2208/Open-Ski-Jumping" alt="Open Ski Jumping" width="300"/>](https://github.com/Jonek2208/Open-Ski-Jumping) |
 | --- |
 | [Open Ski Jumping](https://github.com/Jonek2208/Open-Ski-Jumping) |
+| [<img src="https://opengraph.githubassets.com/1/mertusta1996/Unity-Football-Freekick-Game" alt="Football Freekick" width="300"/>](https://github.com/mertusta1996/Unity-Football-Freekick-Game) | [<img src="https://opengraph.githubassets.com/1/tutsplus/BasketballFreeThrowUnity" alt="Basketball Free Throw" width="300"/>](https://github.com/tutsplus/BasketballFreeThrowUnity) | [<img src="https://opengraph.githubassets.com/1/CompleteUnityDeveloper/08-Bowlmaster-Original" alt="Bowlmaster" width="300"/>](https://github.com/CompleteUnityDeveloper/08-Bowlmaster-Original) |
+| --- | --- | --- |
+| [Football Freekick](https://github.com/mertusta1996/Unity-Football-Freekick-Game) | [Basketball Free Throw](https://github.com/tutsplus/BasketballFreeThrowUnity) | [Bowlmaster](https://github.com/CompleteUnityDeveloper/08-Bowlmaster-Original) |
 
 ## Plataformas
 
 | [<img src="https://opengraph.githubassets.com/1/mollee55/PlatformerMicrogameTutorial" alt="Platformer Microgame" width="300"/>](https://github.com/mollee55/PlatformerMicrogameTutorial) | [<img src="https://opengraph.githubassets.com/1/JasonVanRaamsdonk/Ragnarok" alt="Ragnarok" width="300"/>](https://github.com/JasonVanRaamsdonk/Ragnarok) | [<img src="https://opengraph.githubassets.com/1/Claudiocdj/Super-Mario-Bros-Unity" alt="Super Mario Bros" width="300"/>](https://github.com/Claudiocdj/Super-Mario-Bros-Unity) |
 | --- | --- | --- |
 | [Platformer Microgame](https://github.com/mollee55/PlatformerMicrogameTutorial) | [Ragnarok](https://github.com/JasonVanRaamsdonk/Ragnarok) | [Super Mario Bros](https://github.com/Claudiocdj/Super-Mario-Bros-Unity) |
+| [<img src="https://opengraph.githubassets.com/1/mdechatech/Sonic-Realms" alt="Sonic Realms" width="300"/>](https://github.com/mdechatech/Sonic-Realms) | [<img src="https://opengraph.githubassets.com/1/david-alejandro-reyes-milian/unity3d-super-metroid" alt="Super Metroid" width="300"/>](https://github.com/david-alejandro-reyes-milian/unity3d-super-metroid) | [<img src="https://opengraph.githubassets.com/1/SkyWatchersStudio/Castlevania-SotN" alt="Castlevania SotN" width="300"/>](https://github.com/SkyWatchersStudio/Castlevania-SotN) |
+| --- | --- | --- |
+| [Sonic Realms](https://github.com/mdechatech/Sonic-Realms) | [Unity3D Super Metroid](https://github.com/david-alejandro-reyes-milian/unity3d-super-metroid) | [Castlevania SotN](https://github.com/SkyWatchersStudio/Castlevania-SotN) |
 
 ## Puzzle
 
 | [<img src="https://opengraph.githubassets.com/1/dgkanatsios/MatchThreeGame" alt="Match Three Game" width="300"/>](https://github.com/dgkanatsios/MatchThreeGame) | [<img src="https://opengraph.githubassets.com/1/CompleteUnityDeveloper/Block-Breaker-Original" alt="Block Break Original" width="300"/>](https://github.com/CompleteUnityDeveloper/Block-Breaker-Original) | [<img src="https://opengraph.githubassets.com/1/CompleteUnityDeveloper/05-Block-Breaker" alt="Block Breaker" width="300"/>](https://github.com/CompleteUnityDeveloper/05-Block-Breaker) |
 | --- | --- | --- |
 | [Match Three Game](https://github.com/dgkanatsios/MatchThreeGame) | [Block Break Original](https://github.com/CompleteUnityDeveloper/Block-Breaker-Original) | [Block Breaker](https://github.com/CompleteUnityDeveloper/05-Block-Breaker) |
+| [<img src="https://opengraph.githubassets.com/1/Mukarillo/UnityTetris" alt="Unity Tetris" width="300"/>](https://github.com/Mukarillo/UnityTetris) | [<img src="https://opengraph.githubassets.com/1/FloVnst/Portal3D" alt="Portal 3D" width="300"/>](https://github.com/FloVnst/Portal3D) | [<img src="https://opengraph.githubassets.com/1/ajhager/unity-sokoban" alt="Unity Sokoban" width="300"/>](https://github.com/ajhager/unity-sokoban) |
+| --- | --- | --- |
+| [Unity Tetris](https://github.com/Mukarillo/UnityTetris) | [Portal 3D](https://github.com/FloVnst/Portal3D) | [Unity Sokoban](https://github.com/ajhager/unity-sokoban) |
 
 ## Shooter
 
 | [<img src="https://opengraph.githubassets.com/1/Armour/Multiplayer-FPS" alt="Multiplayer FPS" width="300"/>](https://github.com/Armour/Multiplayer-FPS) | [<img src="https://opengraph.githubassets.com/1/xieliujian/UnityDemo_Splatoon" alt="UnityDemo Splatoon" width="300"/>](https://github.com/xieliujian/UnityDemo_Splatoon) | [<img src="https://opengraph.githubassets.com/1/NamanHegde38/splatoon-2d" alt="Splatoon 2D" width="300"/>](https://github.com/NamanHegde38/splatoon-2d) |
 | --- | --- | --- |
 | [Multiplayer FPS](https://github.com/Armour/Multiplayer-FPS) | [UnityDemo Splatoon](https://github.com/xieliujian/UnityDemo_Splatoon) | [Splatoon 2D](https://github.com/NamanHegde38/splatoon-2d) |
+| [<img src="https://opengraph.githubassets.com/1/jmickle66666666/DoomUnity" alt="Doom Unity" width="300"/>](https://github.com/jmickle66666666/DoomUnity) | [<img src="https://opengraph.githubassets.com/1/weeeBox/quake-one-in-unity" alt="Quake Unity" width="300"/>](https://github.com/weeeBox/quake-one-in-unity) | [<img src="https://opengraph.githubassets.com/1/CptAsgard/CoD2Unity" alt="CoD2 Unity" width="300"/>](https://github.com/CptAsgard/CoD2Unity) |
+| --- | --- | --- |
+| [Doom Unity](https://github.com/jmickle66666666/DoomUnity) | [Quake One in Unity](https://github.com/weeeBox/quake-one-in-unity) | [CoD2 Unity](https://github.com/CptAsgard/CoD2Unity) |
 
 ## Mundo Abierto
 
 | [<img src="https://opengraph.githubassets.com/1/GTA-ASM/SanAndreasUnity" alt="San Andreas Unity" width="300"/>](https://github.com/GTA-ASM/SanAndreasUnity) | [<img src="https://opengraph.githubassets.com/1/daniloabella18/Dune-of-Arrakis-Unity3D" alt="Dune of Arrakis" width="300"/>](https://github.com/daniloabella18/Dune-of-Arrakis-Unity3D) |
 | --- | --- |
 | [San Andreas Unity](https://github.com/GTA-ASM/SanAndreasUnity) | [Dune of Arrakis](https://github.com/daniloabella18/Dune-of-Arrakis-Unity3D) |
+| [<img src="https://opengraph.githubassets.com/1/arycama/MorrowindUnity" alt="Morrowind Unity" width="300"/>](https://github.com/arycama/MorrowindUnity) | [<img src="https://opengraph.githubassets.com/1/unitystation/unitystation" alt="UnityStation" width="300"/>](https://github.com/unitystation/unitystation) | [<img src="https://opengraph.githubassets.com/1/knela96/Dynamic-Parkour-System" alt="Dynamic Parkour" width="300"/>](https://github.com/knela96/Dynamic-Parkour-System) |
+| --- | --- | --- |
+| [Morrowind Unity](https://github.com/arycama/MorrowindUnity) | [UnityStation](https://github.com/unitystation/unitystation) | [Dynamic Parkour System](https://github.com/knela96/Dynamic-Parkour-System) |
 
 ## Indie / Casual
 
@@ -69,12 +99,18 @@ Colección de ejemplos de juegos creados con Unity. Para facilitar la navegació
 | [<img src="https://opengraph.githubassets.com/1/dgkanatsios/FlappyBirdStyleGame" alt="Flappy Bird" width="300"/>](https://github.com/dgkanatsios/FlappyBirdStyleGame) | [<img src="https://opengraph.githubassets.com/1/tutsplus/UnityFruitCutter" alt="Fruit Cutter" width="300"/>](https://github.com/tutsplus/UnityFruitCutter) | [<img src="https://opengraph.githubassets.com/1/Jonek2208/Open-Ski-Jumping" alt="Open Ski Jumping" width="300"/>](https://github.com/Jonek2208/Open-Ski-Jumping) |
 | --- | --- | --- |
 | [Flappy Bird Style Game](https://github.com/dgkanatsios/FlappyBirdStyleGame) | [Unity Fruit Cutter](https://github.com/tutsplus/UnityFruitCutter) | [Open Ski Jumping](https://github.com/Jonek2208/Open-Ski-Jumping) |
+| [<img src="https://opengraph.githubassets.com/1/dgkanatsios/AngryBirdsStyleGame" alt="Angry Birds" width="300"/>](https://github.com/dgkanatsios/AngryBirdsStyleGame) | [<img src="https://opengraph.githubassets.com/1/dgkanatsios/2048" alt="2048" width="300"/>](https://github.com/dgkanatsios/2048) | [<img src="https://opengraph.githubassets.com/1/ulisseslima/CrossyRoad" alt="Crossy Road" width="300"/>](https://github.com/ulisseslima/CrossyRoad) |
+| --- | --- | --- |
+| [Angry Birds Style Game](https://github.com/dgkanatsios/AngryBirdsStyleGame) | [2048](https://github.com/dgkanatsios/2048) | [Crossy Road](https://github.com/ulisseslima/CrossyRoad) |
 
 ## Otros
 
 | [<img src="https://opengraph.githubassets.com/1/UnityTechnologies/open-project-1" alt="Chop Chop" width="300"/>](https://github.com/UnityTechnologies/open-project-1) | [<img src="https://opengraph.githubassets.com/1/ditzel/LegoGame" alt="Lego Game" width="300"/>](https://github.com/ditzel/LegoGame) | [<img src="https://opengraph.githubassets.com/1/Brackeys/Tower-Defense-Tutorial" alt="Tower Defense Tutorial" width="300"/>](https://github.com/Brackeys/Tower-Defense-Tutorial) |
 | --- | --- | --- |
 | [Chop Chop](https://github.com/UnityTechnologies/open-project-1) | [Lego Game](https://github.com/ditzel/LegoGame) | [Brackeys Tower Defense Tutorial](https://github.com/Brackeys/Tower-Defense-Tutorial) |
+| [<img src="https://opengraph.githubassets.com/1/samhogan/Minecraft-Unity3D" alt="Minecraft Unity" width="300"/>](https://github.com/samhogan/Minecraft-Unity3D) | [<img src="https://opengraph.githubassets.com/1/KBFSantos/AmongUs-FanMade-remake" alt="Among Us" width="300"/>](https://github.com/KBFSantos/AmongUs-FanMade-remake) | [<img src="https://opengraph.githubassets.com/1/TungDuongTa/CelesteLike" alt="Celeste Like" width="300"/>](https://github.com/TungDuongTa/CelesteLike) |
+| --- | --- | --- |
+| [Minecraft Unity3D](https://github.com/samhogan/Minecraft-Unity3D) | [Among Us FanMade](https://github.com/KBFSantos/AmongUs-FanMade-remake) | [Celeste Like](https://github.com/TungDuongTa/CelesteLike) |
 
 
 | [<img src="https://opengraph.githubassets.com/1/stormtek/unity-rts-demo" alt="Unity RTS Demo" width="300"/>](https://github.com/stormtek/unity-rts-demo) |

--- a/Proyectos/NonGames/README.md
+++ b/Proyectos/NonGames/README.md
@@ -13,6 +13,9 @@ Colección de utilidades, herramientas y demos realizadas con Unity.
 | [<img src="https://opengraph.githubassets.com/1/aren227/unity-fluid-simulation" alt="Unity Fluid Simulation" width="300"/>](https://github.com/aren227/unity-fluid-simulation) | [<img src="https://opengraph.githubassets.com/1/eliasts/Ocean_Community_Next_Gen" alt="Ocean Community" width="300"/>](https://github.com/eliasts/Ocean_Community_Next_Gen) | [<img src="https://opengraph.githubassets.com/1/RobotecAI/ros2-for-unity" alt="ROS2 for Unity" width="300"/>](https://github.com/RobotecAI/ros2-for-unity) |
 | --- | --- | --- |
 | [Unity Fluid Simulation](https://github.com/aren227/unity-fluid-simulation) | [Ocean Community Next Gen](https://github.com/eliasts/Ocean_Community_Next_Gen) | [ROS2 for Unity](https://github.com/RobotecAI/ros2-for-unity) |
+| [<img src="https://opengraph.githubassets.com/1/Unity-Technologies/ml-agents" alt="ML Agents" width="300"/>](https://github.com/Unity-Technologies/ml-agents) | [<img src="https://opengraph.githubassets.com/1/Unity-Technologies/EntityComponentSystemSamples" alt="ECS Samples" width="300"/>](https://github.com/Unity-Technologies/EntityComponentSystemSamples) | [<img src="https://opengraph.githubassets.com/1/Unity-Technologies/com.unity.uiwidgets" alt="UIWidgets" width="300"/>](https://github.com/Unity-Technologies/com.unity.uiwidgets) |
+| --- | --- | --- |
+| [ML-Agents](https://github.com/Unity-Technologies/ml-agents) | [Entity Component System Samples](https://github.com/Unity-Technologies/EntityComponentSystemSamples) | [UIWidgets](https://github.com/Unity-Technologies/com.unity.uiwidgets) |
 
 ## Escenas de ejemplo
 


### PR DESCRIPTION
## Summary
- include open source clones of classic titles across multiple genres in Games README
- add notable Unity tools like ML-Agents in NonGames README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68820105834483269cdb02ee18db1270